### PR TITLE
Updated Polygon Streaming attributes to support Web SDK 2.9.0

### DIFF
--- a/lib/plugin/media/configs.ts
+++ b/lib/plugin/media/configs.ts
@@ -116,8 +116,9 @@ export const polygonStreamingConfigs: polygonStreamingSchemas = {
       default: ''
     },
     {
-      name: 'animationStateGraphId',
-      type: 'number',
+      name: 'animationStateGraph',
+      type: 'assetId',
+      assetType: 'animstategraph',
       default: 0
     },
     {
@@ -144,8 +145,38 @@ export const polygonStreamingConfigs: polygonStreamingSchemas = {
       ]
     },
     {
-      name: 'environmentAssetId',
-      type: 'number',
+      name: 'vrmAnimations',
+      type: 'json',
+      array: true,
+      default: [],
+      schema: [
+        {
+          name: 'name',
+          type: 'string',
+          default: ''
+        },
+        {
+          name: 'asset',
+          type: 'assetId',
+          default: 0,
+          assetType: 'binary'
+        },
+        {
+          name: 'loop',
+          type: 'boolean',
+          default: true
+        },
+        {
+          name: 'default',
+          type: 'boolean',
+          default: false
+        }
+      ]
+    },
+    {
+      name: 'environmentAsset',
+      type: 'assetId',
+      assetType: ['cubemap', 'texture'],
       default: 0,
     },
   ],

--- a/lib/plugin/media/desc.ts
+++ b/lib/plugin/media/desc.ts
@@ -114,6 +114,9 @@ export const Desc = {
     animation: {
       desc: 'Animation To Play'
     },
+    animationStateGraph: {
+      desc: 'Animation State Graph'
+    },
     animationStateMappings: {
       desc: 'Animation States',
       children: {
@@ -128,8 +131,22 @@ export const Desc = {
         }
       }
     },
-    animationStateGraphId: {
-      desc: 'Animation State Graph'
+    vrmAnimations: {
+      desc: 'VRM Animations',
+      children: {
+        name: {
+          desc: 'Name'
+        },
+        asset: {
+          desc: 'VRMA Asset'
+        },
+        loop: {
+          desc: 'Loop'
+        },
+        default: {
+          desc: 'Default'
+        }
+      }
     },
     priorityLevel: {
       desc: 'Priority Level',
@@ -137,7 +154,7 @@ export const Desc = {
     qualityPriority: {
       desc: 'Quality Priority',
     },
-    environmentAssetId: {
+    environmentAsset: {
       desc: 'Environment Asset',
     },
   },

--- a/lib/plugin/type.ts
+++ b/lib/plugin/type.ts
@@ -47,13 +47,38 @@ type SchemaTypes = {
   vec3: [number, number, number];
   vec2: [number, number];
   unixEpochMs: string;
+  assetId: number;
 };
+
+// assetType: https://developer.playcanvas.com/en/typedocs/classes/Asset.html#type
+export type AssetType =
+  | 'animation'
+  | 'container'
+  | 'font'
+  | 'audio'
+  | 'html'
+  | 'script'
+  | 'template'
+  | 'text'
+  | 'json'
+  | 'binary'
+  | 'texture'
+  | 'cubemap'
+  | 'model'
+  | 'sprite'
+  | 'render'
+  | 'css'
+  | 'material'
+  | 'shader'
+  | 'textureatlas'
+  | 'animstategraph'
 
 type Schema<K extends keyof SchemaTypes> = {
   name: string;
   type: K;
   default?: SchemaTypes[K];
   enum?: (string | number)[] | Record<string, string | number>;
+  assetType?: AssetType | AssetType[];
 } & FunctionTypesMap;
 
 export type Schemas = (
@@ -64,6 +89,7 @@ export type Schemas = (
   | Schema<'vec3'>
   | Schema<'vec2'>
   | Schema<'unixEpochMs'>
+  | Schema<'assetId'>
 )[];
 
 export type ConfigsType = {


### PR DESCRIPTION
- Added new type - assetId that takes a number. Attributes with this type will show up as an asset picker in the editor extension. PlayCanvas will automatically convert asset IDs to assets when you set the attribute value in the script component. I added the type because VRM animation attributes has a nested attribute that is an asset.
- Added VRM animation attributes for Polygon Streaming.