### PR TITLE
Added iosMemoryLimit attribute to polygonStreamingConfigs

### DIFF
--- a/lib/plugin/media/configs.ts
+++ b/lib/plugin/media/configs.ts
@@ -64,9 +64,9 @@ export const polygonStreamingConfigs: polygonStreamingSchemas = {
       default: 15000,
     },
     {
-      name: 'maximumQuality',
+      name: 'iosMemoryLimit',
       type: 'number',
-      default: 15000,
+      default: 0,
     },
   ],
   streamableModel: [


### PR DESCRIPTION
maximumQuality attribute was repeated twice so I replaced the 2nd instance with iosMemoryLimit attribute.